### PR TITLE
chore: Add dummy build reusable workflow

### DIFF
--- a/.github/workflows/dummy-build.yml
+++ b/.github/workflows/dummy-build.yml
@@ -1,0 +1,10 @@
+name: Dummy build
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - run: echo "No build required"


### PR DESCRIPTION
the build requirement is baked as a branch protection rule, though we may not always need/want to create a new AMI. For more info: https://stackoverflow.com/questions/69348532/github-actions-required-status-check-doesnt-run-due-to-files-in-paths-not-chan